### PR TITLE
fix: correct docker path and context in azure.yaml

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -22,40 +22,40 @@ services:
     language: py
     host: containerapp
     docker:
-      path: ./backend/Dockerfile
-      context: ./backend
+      path: ./Dockerfile
+      context: .
   transactions-service:
     project: ./backend
     language: py
     host: containerapp
     docker:
-      path: ./backend/Dockerfile.transactions
-      context: ./backend
+      path: ./Dockerfile.transactions
+      context: .
   payments-service:
     project: ./backend
     language: py
     host: containerapp
     docker:
-      path: ./backend/Dockerfile.payments
-      context: ./backend
+      path: ./Dockerfile.payments
+      context: .
   account-mcp:
     project: ./backend
     language: py
     host: containerapp
     docker:
-      path: ./backend/Dockerfile.account-mcp
-      context: ./backend
+      path: ./Dockerfile.account-mcp
+      context: .
   transactions-mcp:
     project: ./backend
     language: py
     host: containerapp
     docker:
-      path: ./backend/Dockerfile.transactions-mcp
-      context: ./backend
+      path: ./Dockerfile.transactions-mcp
+      context: .
   payments-mcp:
     project: ./backend
     language: py
     host: containerapp
     docker:
-      path: ./backend/Dockerfile.payments-mcp
-      context: ./backend
+      path: ./Dockerfile.payments-mcp
+      context: .


### PR DESCRIPTION
## Problem
Docker image builds were failing with:
```
ERROR: failed to build: unable to prepare context: path "./backend" not found
```

## Root Cause
In `azure.yaml`, the `docker.path` and `docker.context` values were specified relative to the repo root, but `azd` resolves them relative to the `project` directory (`./backend`). This caused paths to resolve to `./backend/backend`, which doesn't exist.

## Fix
Updated all six services to use paths relative to the project directory:
- `path: ./Dockerfile.*` (was `./backend/Dockerfile.*`)
- `context: .` (was `./backend`)

Affected services: backend, transactions-service, payments-service, account-mcp, transactions-mcp, payments-mcp.